### PR TITLE
Store in explicit local dict instead of local.__dict__ and optimize restore

### DIFF
--- a/threadsafevariable/__init__.py
+++ b/threadsafevariable/__init__.py
@@ -8,7 +8,6 @@ __version__ = 20250716.1
 class ThreadSafeVariable:
 
     storage = threading.local()
-    storage.vars = {}
     master_thread = threading.current_thread()
     defaults = {}
     

--- a/threadsafevariable/__init__.py
+++ b/threadsafevariable/__init__.py
@@ -11,15 +11,22 @@ class ThreadSafeVariable:
     storage.vars = {}
     master_thread = threading.current_thread()
     defaults = {}
+    
+    @staticmethod
+    def ensure_vars():
+        if getattr(ThreadSafeVariable.storage, "vars", None) is None:
+            ThreadSafeVariable.storage.vars = {}
 
     def __set__(self, instance, value):
         key = "%s.%s" % (id(instance), id(self))
         if self.master_thread == threading.current_thread():
             self.defaults[key] = value
+        self.ensure_vars()
         self.storage.vars[key] = value
 
     def __get__(self, instance, owner):
         key = "%s.%s" % (id(instance), id(self))
+        self.ensure_vars()
         try:
             return self.storage.vars[key]
         except KeyError: 
@@ -27,8 +34,10 @@ class ThreadSafeVariable:
 
     @staticmethod
     def freeze():
+        ThreadSafeVariable.ensure_vars()
         return copy.copy(ThreadSafeVariable.storage.vars)
 
     @staticmethod
     def restore(image):
+        ThreadSafeVariable.ensure_vars()
         ThreadSafeVariable.storage.vars = copy.copy(image)


### PR DESCRIPTION
The way restoring the ThreadSafeVariable icecube worked before was pretty suboptimal, causing a surprising performance loss.

I've re-written it to use an explicit dictionary instead of storing variables in `local.__dict__`, and then used copy to restore instead of looping over all variables.

In my project, with a decent number of DAL tables, I noticed this difference in total runtime:

Before: 7%
<img width="674" height="120" alt="image" src="https://github.com/user-attachments/assets/6fdd6ffd-0183-46b6-ba08-95f22a8c7b53" />

After: 0.23%
<img width="528" height="70" alt="image" src="https://github.com/user-attachments/assets/60c2c6ac-4448-4819-bd29-0a08b16b666c" />

Profiler used:
`py-spy record -t -r 1000 -f speedscope -o ./profile.speedscope --pid <actualy python process PID>`

I've tested the changes with these 2 actions:
```py
@action("set")
@action.uses(db)
def set():
    db.table.field.default = "TEST"
    return db.table.field.default # should return TEST

@action("read")
@action.uses(db)
def read():
    return db.table.field.default # should NOT return TEST
```